### PR TITLE
Cal/vnext

### DIFF
--- a/docs/todo.txt
+++ b/docs/todo.txt
@@ -34,8 +34,6 @@ LOW PRIORITY
 -display draw calls and tris/verts
 -fix naming of user components in gui
 -main window/main menu dilemma
--meshes are loaded even if v/i buffers already exist(in Model constructor)
-        -note: the 'shared' buffers are ultimately used, but file reading happens for each instance regardless
 -camera needs parameters for fov/clipping planes
 -Entity (and other places) - many public methods could be private if Engine was friend
 -make generating new user types easier/quicker (untility prog?)

--- a/nc/source/component/PointLight.h
+++ b/nc/source/component/PointLight.h
@@ -8,7 +8,7 @@ namespace nc::graphics { class Graphics; }
 
 namespace nc
 {
-    //class Transform;
+    class Transform;
 
     class PointLight : public Component
     {

--- a/nc/source/component/Renderer.cpp
+++ b/nc/source/component/Renderer.cpp
@@ -29,6 +29,10 @@ namespace nc
         m_model = std::move(other.m_model);
     }
 
+    Renderer::~Renderer()
+    {
+    }
+
     Renderer& Renderer::operator=(Renderer&& other)
     {
         m_handle = other.GetHandle();

--- a/nc/source/component/Renderer.h
+++ b/nc/source/component/Renderer.h
@@ -6,7 +6,13 @@
 
 #include <memory>
 
-namespace nc::graphics { class Model; class Mesh; class Material; class Graphics; class PBRMaterial;}
+namespace nc::graphics
+{
+    class Graphics;
+    class Material;
+    class Mesh;
+    class Model;
+    class PBRMaterial;}
 
 namespace nc
 {
@@ -21,7 +27,7 @@ namespace nc
             Renderer(Renderer&&);
             Renderer& operator=(const Renderer&) = delete;
             Renderer& operator=(Renderer&&);
-            ~Renderer() = default;
+            ~Renderer();
 
             #ifdef NC_EDITOR_ENABLED
             void EditorGuiElement() override;

--- a/nc/source/component/Renderer.h
+++ b/nc/source/component/Renderer.h
@@ -9,7 +9,6 @@
 namespace nc::graphics
 {
     class Graphics;
-    class Material;
     class Mesh;
     class Model;
     class PBRMaterial;}

--- a/nc/source/ecs/Entity.cpp
+++ b/nc/source/ecs/Entity.cpp
@@ -18,6 +18,10 @@ Entity::Entity(Entity&& other)
 {
 }
 
+Entity::~Entity()
+{
+}
+
 Entity& Entity::operator=(Entity&& other)
 {
     Handle = std::exchange(other.Handle, NullHandle);

--- a/nc/source/ecs/Entity.h
+++ b/nc/source/ecs/Entity.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "component/Component.h"
+#include "component/EngineComponentGroup.h"
+
 #include <vector>
 #include <memory>
 #include <string>
-#include "component/Component.h"
-#include "component/EngineComponentGroup.h"
 
 namespace nc
 {
@@ -18,7 +19,7 @@ namespace nc
             Entity& operator=(const Entity&) = delete;
             Entity(Entity&& other);
             Entity& operator=(Entity&& other);
-            ~Entity() = default;
+            ~Entity();
 
             mutable EntityHandle Handle;
             mutable std::string Tag;

--- a/nc/source/graphics/Mesh.cpp
+++ b/nc/source/graphics/Mesh.cpp
@@ -64,7 +64,7 @@ namespace nc::graphics
 
         // Load vertex and normal data
         meshData.Vertices.reserve(pMesh -> mNumVertices);
-        for (unsigned int i = 0; i < pMesh->mNumVertices; i++)
+        for (size_t i = 0; i < pMesh->mNumVertices; i++)
         {
             meshData.Vertices.push_back( {
                 *reinterpret_cast<DirectX::XMFLOAT3*>(&pMesh->mVertices[i]),
@@ -76,9 +76,8 @@ namespace nc::graphics
         }
 
         // Load index data
-        std::vector<unsigned short> indices;
         meshData.Indices.reserve(pMesh -> mNumFaces * 3); // Multiply by 3 because we told assimp to triangulate (aiProcess_Triangulate). Each face has 3 indices
-        for (unsigned int i = 0; i < pMesh->mNumFaces; i++)
+        for (size_t i = 0; i < pMesh->mNumFaces; i++)
         {
             const auto& face = pMesh->mFaces[i];
             assert(face.mNumIndices == 3);

--- a/nc/source/graphics/Mesh.cpp
+++ b/nc/source/graphics/Mesh.cpp
@@ -1,12 +1,13 @@
-#include "NcDebug.h"
 #include "graphics\d3dresource\GraphicsResourceManager.h"
 #include "graphics\Mesh.h"
 #include "NcConfig.h"
+#include "NcDebug.h"
+#include "Vertex.h"
+
 #include <assimp\Importer.hpp>
 #include <assimp\scene.h>
 #include <assimp\postprocess.h>
 #include <vector>
-#include "external\include\directx\math\DirectXMath.h"
 
 const char separator = 
 #ifdef _WIN32
@@ -15,11 +16,30 @@ const char separator =
     '/';
 #endif
 
-
-namespace nc::graphics::detail
+namespace
 {
-    bool HasValidMeshExtension(const std::string& fileExtension) 
+    constexpr auto AssimpFlags = aiProcess_Triangulate |
+                                  aiProcess_JoinIdenticalVertices |
+                                  aiProcess_ConvertToLeftHanded |
+                                  aiProcess_GenNormals |
+                                  aiProcess_CalcTangentSpace;
+
+    constexpr auto DefaultPrimitiveTopology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+
+    const auto DefaultInputElementDesc = std::vector<D3D11_INPUT_ELEMENT_DESC>
     {
+        { "Position", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,  0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "Normal", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "TexCoord", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 24, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "Tangent", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "Bitangent", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 44, D3D11_INPUT_PER_VERTEX_DATA, 0 }
+    };
+
+    bool HasValidMeshExtension(const std::string& path) 
+    {
+        std::size_t periodPosition = path.rfind('.');
+        const std::string fileExtension = path.substr(periodPosition+1);
+
         if (fileExtension.compare("fbx") == 0 || fileExtension.compare("FBX") == 0)
         {
             return true;
@@ -31,42 +51,22 @@ namespace nc::graphics::detail
         return false;
     }
 
-    std::string GetMeshFileName(const std::string& meshPath) 
+    void ParseMesh(std::string meshPath, std::vector<nc::graphics::Vertex>& vBuffOut, std::vector<uint16_t>& iBuffOut)
     {
-        std::size_t fileNameStartPosition = meshPath.rfind(separator);
-        const std::string& fileNameWithExtension = meshPath.substr(fileNameStartPosition+1);
-        std::size_t periodPosition = fileNameWithExtension.find('.');
-        const std::string& fileExtension = fileNameWithExtension.substr(periodPosition+1);
-
-        if (!HasValidMeshExtension(fileExtension)) 
+        if (!HasValidMeshExtension(meshPath))
         {
-           throw std::runtime_error("nc::graphics::detail::GetMeshFileName::HasValidMeshExtension - Invalid file type loaded for mesh.");
+            throw std::runtime_error("Invalid mesh file extension");
         }
 
-        return fileNameWithExtension.substr(0, periodPosition);
-    } 
-}
-
-namespace nc::graphics
-{
-    Mesh::Mesh(std::string meshPath)
-    {
-        InitializeGraphicsPipeline(Mesh::ParseMesh(std::move(meshPath)));
-    }
-
-    MeshData Mesh::ParseMesh(std::string meshPath) 
-    {
-        MeshData meshData;
-        meshData.MeshPath = std::move(meshPath);
         Assimp::Importer imp;
-        const auto pModel = imp.ReadFile(meshData.MeshPath, aiProcess_Triangulate | aiProcess_JoinIdenticalVertices | aiProcess_ConvertToLeftHanded | aiProcess_GenNormals | aiProcess_CalcTangentSpace); // ConvertToLeftHanded formats the output to match DirectX
+        const auto pModel = imp.ReadFile(meshPath, AssimpFlags);
         const auto pMesh = pModel->mMeshes[0];
 
         // Load vertex and normal data
-        meshData.Vertices.reserve(pMesh -> mNumVertices);
+        vBuffOut.reserve(pMesh -> mNumVertices);
         for (size_t i = 0; i < pMesh->mNumVertices; i++)
         {
-            meshData.Vertices.push_back( {
+            vBuffOut.push_back( {
                 *reinterpret_cast<DirectX::XMFLOAT3*>(&pMesh->mVertices[i]),
                 *reinterpret_cast<DirectX::XMFLOAT3*>(&pMesh->mNormals[i]),
                 *reinterpret_cast<DirectX::XMFLOAT2*>(&pMesh->mTextureCoords[0][i]),
@@ -76,41 +76,48 @@ namespace nc::graphics
         }
 
         // Load index data
-        meshData.Indices.reserve(pMesh -> mNumFaces * 3); // Multiply by 3 because we told assimp to triangulate (aiProcess_Triangulate). Each face has 3 indices
+        iBuffOut.reserve(pMesh -> mNumFaces * 3); // Multiply by 3 because we told assimp to triangulate (aiProcess_Triangulate). Each face has 3 indices
         for (size_t i = 0; i < pMesh->mNumFaces; i++)
         {
             const auto& face = pMesh->mFaces[i];
             assert(face.mNumIndices == 3);
-            meshData.Indices.push_back(face.mIndices[0]);
-            meshData.Indices.push_back(face.mIndices[1]);
-            meshData.Indices.push_back(face.mIndices[2]);
+            iBuffOut.push_back(face.mIndices[0]);
+            iBuffOut.push_back(face.mIndices[1]);
+            iBuffOut.push_back(face.mIndices[2]);
+        }
+    }
+} // end anonymous namespace
+
+namespace nc::graphics
+{
+    using namespace nc::graphics::d3dresource;
+
+    Mesh::Mesh(std::string meshPath)
+    {
+        auto defaultShaderPath = nc::config::NcGetConfigReference().graphics.shadersPath;
+        auto pvs = GraphicsResourceManager::Acquire<VertexShader>(std::move(defaultShaderPath) + "pbrvertexshader.cso");
+        auto pvsbc = static_cast<VertexShader&>(*pvs).GetBytecode();
+        AddGraphicsResource(std::move(pvs));
+        AddGraphicsResource(GraphicsResourceManager::Acquire<InputLayout> (meshPath, DefaultInputElementDesc, pvsbc));
+        AddGraphicsResource(GraphicsResourceManager::Acquire<Topology> (DefaultPrimitiveTopology));
+        AddBufferResources(std::move(meshPath));
+    }
+
+    void Mesh::AddBufferResources(std::string meshPath)
+    {
+        auto vertexBuffer = std::vector<Vertex>{};
+        auto indexBuffer = std::vector<uint16_t>{};
+
+        auto vBufferExists = GraphicsResourceManager::Exists<VertexBuffer>(vertexBuffer, meshPath);
+        auto iBufferExists = GraphicsResourceManager::Exists<IndexBuffer>(indexBuffer, meshPath);
+
+        if (!(vBufferExists && iBufferExists))
+        {
+            ParseMesh(meshPath, vertexBuffer, indexBuffer);
         }
 
-        meshData.Name = detail::GetMeshFileName(meshData.MeshPath);
-        meshData.PrimitiveTopology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
-        meshData.InputElementDesc = 
-        {
-            { "Position", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,  0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-            { "Normal", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-            { "TexCoord", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 24, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-            { "Tangent", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-            { "Bitangent", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 44, D3D11_INPUT_PER_VERTEX_DATA, 0 }
-        };
-        return meshData;
+        // If the resource already exists, we can safely pass in empty buffers
+        AddGraphicsResource(GraphicsResourceManager::Acquire<VertexBuffer>(vertexBuffer, meshPath));
+        AddGraphicsResource(GraphicsResourceManager::Acquire<IndexBuffer>(indexBuffer, meshPath));
     }
-
-    void Mesh::InitializeGraphicsPipeline(MeshData meshData)
-    {
-        using namespace nc::graphics::d3dresource;
-
-        auto defaultShaderPath = nc::config::NcGetConfigReference().graphics.shadersPath;
-
-        auto pvs = d3dresource::GraphicsResourceManager::Acquire<d3dresource::VertexShader>(std::move(defaultShaderPath) + "pbrvertexshader.cso");
-        auto pvsbc = static_cast<VertexShader&>(*pvs).GetBytecode();
-        Mesh::AddGraphicsResource(std::move(pvs));
-        Mesh::AddGraphicsResource(GraphicsResourceManager::Acquire<VertexBuffer>(meshData.Vertices, meshData.MeshPath));
-        Mesh::AddGraphicsResource(GraphicsResourceManager::Acquire<IndexBuffer> (meshData.Indices, meshData.MeshPath));
-        Mesh::AddGraphicsResource(GraphicsResourceManager::Acquire<InputLayout> (meshData.MeshPath, meshData.InputElementDesc, pvsbc));
-        Mesh::AddGraphicsResource(GraphicsResourceManager::Acquire<Topology>    (meshData.PrimitiveTopology));
-    }
-}
+} // end namespace nc::graphics

--- a/nc/source/graphics/Mesh.h
+++ b/nc/source/graphics/Mesh.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "directx/math/DirectXMath.h"
-#include <d3d11.h>
+#include "ResourceGroup.h"
+
 #include <string>
 #include <vector>
 
@@ -13,28 +13,6 @@ namespace nc::graphics
         class GraphicsResource;
         class IndexBuffer;
     }
-}
-
-namespace nc::graphics
-{
-    struct Vertex
-    {
-        DirectX::XMFLOAT3 pos;
-        DirectX::XMFLOAT3 normal;
-        DirectX::XMFLOAT2 uvs;
-        DirectX::XMFLOAT3 tangent;
-        DirectX::XMFLOAT3 bitangent;
-    };
-
-    struct MeshData
-    {
-        std::string                           Name;
-        std::string                           MeshPath;
-        D3D_PRIMITIVE_TOPOLOGY                PrimitiveTopology;
-        std::vector<D3D11_INPUT_ELEMENT_DESC> InputElementDesc;
-        std::vector<Vertex>                   Vertices;
-        std::vector<uint16_t>                 Indices;
-    };
 
     class Mesh : public ResourceGroup
     {
@@ -46,9 +24,8 @@ namespace nc::graphics
             Mesh& operator=(Mesh&& other) = default;
             Mesh& operator=(const Mesh& other) = default;
             ~Mesh() = default;
-            MeshData ParseMesh(std::string meshPath);
-
+        
         private:
-            void InitializeGraphicsPipeline(MeshData meshData);
+            void AddBufferResources(std::string meshPath);
     };
 }

--- a/nc/source/graphics/Vertex.h
+++ b/nc/source/graphics/Vertex.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "directx/math/DirectXMath.h"
+
+namespace nc::graphics
+{
+    struct Vertex
+    {
+        DirectX::XMFLOAT3 pos;
+        DirectX::XMFLOAT3 normal;
+        DirectX::XMFLOAT2 uvs;
+        DirectX::XMFLOAT3 tangent;
+        DirectX::XMFLOAT3 bitangent;
+    };
+}

--- a/nc/source/graphics/d3dresource/GraphicsResource.cpp
+++ b/nc/source/graphics/d3dresource/GraphicsResource.cpp
@@ -1,5 +1,6 @@
 #include "GraphicsResource.h"
 #include "graphics/Graphics.h"
+#include "graphics/Model.h"
 #include "graphics/WICTextureLoader.h"
 #include "directx/math/DirectXMath.h"
 #include "component/Transform.h"
@@ -248,7 +249,7 @@ namespace nc::graphics::d3dresource
 
 
 
-    Topology::Topology( D3D11_PRIMITIVE_TOPOLOGY type)
+    Topology::Topology(D3D11_PRIMITIVE_TOPOLOGY type)
         : m_type(type)
     {
     }

--- a/nc/source/graphics/d3dresource/GraphicsResource.h
+++ b/nc/source/graphics/d3dresource/GraphicsResource.h
@@ -2,16 +2,22 @@
 
 #include "GraphicsResourceManager.h"
 #include "graphics/DXException.h"
-#include "graphics/Model.h" //for Vertex
+#include "graphics/Vertex.h"
+//#include "graphics/Model.h" //for Vertex
 
 #include <vector>
 #include <d3d11.h>
 #include <wrl/client.h>
 #include <string>
 #include <stdint.h>
+#include <memory>
 
-namespace nc::graphics { class  Graphics; }
-namespace DirectX      { struct XMMATRIX; }
+namespace nc::graphics
+{
+    class  Graphics;
+    class Model;
+}
+namespace DirectX { struct XMMATRIX; }
 
 
 /* Base wrapper for d3d11 resource */

--- a/nc/source/graphics/d3dresource/GraphicsResource.h
+++ b/nc/source/graphics/d3dresource/GraphicsResource.h
@@ -3,7 +3,6 @@
 #include "GraphicsResourceManager.h"
 #include "graphics/DXException.h"
 #include "graphics/Vertex.h"
-//#include "graphics/Model.h" //for Vertex
 
 #include <vector>
 #include <d3d11.h>
@@ -14,11 +13,10 @@
 
 namespace nc::graphics
 {
-    class  Graphics;
+    class Graphics;
     class Model;
 }
 namespace DirectX { struct XMMATRIX; }
-
 
 /* Base wrapper for d3d11 resource */
 namespace nc::graphics::d3dresource

--- a/nc/source/graphics/d3dresource/GraphicsResourceManager.h
+++ b/nc/source/graphics/d3dresource/GraphicsResourceManager.h
@@ -35,6 +35,12 @@ namespace nc::graphics::d3dresource
                 return Get().Acquire_<T>(std::forward<Params>(p)...);
             }
 
+            template<class T, class = typename std::enable_if<std::is_base_of<GraphicsResource, T>::value>::type, typename...Params>
+            static bool Exists(Params&&...p)
+            {
+                return Get().Exists_<T>(std::forward<Params>(p)...);
+            }
+
             static uint32_t AssignId()
             {
                 return Get().m_resourceId++;
@@ -68,6 +74,18 @@ namespace nc::graphics::d3dresource
                     return res;
                 }
                 return i->second;
+            }
+
+            template<class T, class = typename std::enable_if<std::is_base_of<GraphicsResource, T>::value>::type, typename...Params>
+            bool Exists_(Params&&...p)
+            {
+                const auto key = T::GetUID(std::forward<Params>(p)...);
+                const auto i = m_resources.find(key);
+                if(i == m_resources.end())
+                {
+                    return false;
+                }
+                return true;
             }
 
             void DisplayResources_(bool* open)

--- a/nc/source/graphics/d3dresource/GraphicsResourceManager.h
+++ b/nc/source/graphics/d3dresource/GraphicsResourceManager.h
@@ -18,6 +18,9 @@ namespace nc::graphics::d3dresource
     
     class GraphicsResourceManager
     {
+        template<class T>
+        using is_resource_t = typename std::enable_if_t<std::is_base_of_v<GraphicsResource, T>>;
+
         public:
             static void SetGraphics(Graphics * gfx)
             {
@@ -29,13 +32,13 @@ namespace nc::graphics::d3dresource
                 return Get().m_graphics;
             }
 
-            template<class T, class = typename std::enable_if<std::is_base_of<GraphicsResource, T>::value>::type, typename...Params>
+            template<class T, class = is_resource_t<T>, typename...Params>
             static std::shared_ptr<GraphicsResource> Acquire(Params&&...p)
             {
                 return Get().Acquire_<T>(std::forward<Params>(p)...);
             }
 
-            template<class T, class = typename std::enable_if<std::is_base_of<GraphicsResource, T>::value>::type, typename...Params>
+            template<class T, class = is_resource_t<T>, typename...Params>
             static bool Exists(Params&&...p)
             {
                 return Get().Exists_<T>(std::forward<Params>(p)...);
@@ -62,7 +65,7 @@ namespace nc::graphics::d3dresource
                 return instance;
             }
 
-            template<class T, class = typename std::enable_if<std::is_base_of<GraphicsResource, T>::value>::type, typename...Params>
+            template<class T, class = is_resource_t<T>, typename...Params>
             std::shared_ptr<GraphicsResource> Acquire_(Params&&...p)
             {
                 const auto key = T::GetUID(std::forward<Params>(p)...);
@@ -76,7 +79,7 @@ namespace nc::graphics::d3dresource
                 return i->second;
             }
 
-            template<class T, class = typename std::enable_if<std::is_base_of<GraphicsResource, T>::value>::type, typename...Params>
+            template<class T, class = is_resource_t<T>, typename...Params>
             bool Exists_(Params&&...p)
             {
                 const auto key = T::GetUID(std::forward<Params>(p)...);


### PR DESCRIPTION
Added an Exists method to GraphicsResourceManager so the Mesh constructor can query if the needed buffers exist before invoking AssImp. Vertex was moved to its own file so that including Mesh.h doesn't also include DirectXMath.