### PR TITLE
shared ptrs to unique

### DIFF
--- a/docs/todo.txt
+++ b/docs/todo.txt
@@ -1,7 +1,6 @@
 ***********
 IN PROGRESS
 ***********
-GfxResManager can probably use unique_ptr and return *
 
 ***********
 BUGS

--- a/nc/source/component/PointLightManager.cpp
+++ b/nc/source/component/PointLightManager.cpp
@@ -8,6 +8,13 @@ namespace nc
 {
     const uint32_t PointLightManager::MAX_POINT_LIGHTS;
 
+    PointLightManager::PointLightManager()
+        : m_currentIndex{0u},
+          m_pointLightsArrayConstBufData{},
+          m_constantBuffer{std::make_unique<graphics::d3dresource::PixelConstantBuffer<PointLightsArrayCBuf>>(m_pointLightsArrayConstBufData, 0u)}
+    {
+    }
+
     uint32_t PointLightManager::GetNextAvailableIndex()
     {
         if (m_currentIndex == MAX_POINT_LIGHTS)
@@ -27,9 +34,7 @@ namespace nc
 
     void PointLightManager::Bind()
     {
-        using namespace nc::graphics::d3dresource;
-
-        auto pointLightArray = PixelConstantBuffer<PointLightsArrayCBuf>::AcquireUnique(PointLightManager::m_pointLightsArrayConstBufData, 0u);
-        pointLightArray->Bind();
+        m_constantBuffer->Update(m_pointLightsArrayConstBufData);
+        m_constantBuffer->Bind();
     }
 }

--- a/nc/source/component/PointLightManager.h
+++ b/nc/source/component/PointLightManager.h
@@ -2,7 +2,15 @@
 
 #include "PointLight.h"
 
-namespace nc::graphics { class Graphics; }
+namespace nc::graphics
+{
+    class Graphics;
+    namespace d3dresource
+    {
+        template<typename T>
+        class PixelConstantBuffer;
+    }
+}
 namespace DirectX { struct XMMATRIX; }
 
 namespace nc
@@ -12,20 +20,21 @@ namespace nc
     class PointLightManager
     {
         public:
-
-            PointLightManager() = default;
-            ~PointLightManager() = default;
             static const uint32_t MAX_POINT_LIGHTS = 4u;
+
+            PointLightManager();
             uint32_t GetNextAvailableIndex();
             void AddPointLight(PointLight& pointLight, const DirectX::XMMATRIX& camMatrix);
             void Bind();
 
         private:
-
             uint32_t m_currentIndex;
+
             struct PointLightsArrayCBuf
             {
                PointLight::PointLightPixelCBuf PointLights[MAX_POINT_LIGHTS]; 
             } m_pointLightsArrayConstBufData;
+
+            std::unique_ptr<graphics::d3dresource::PixelConstantBuffer<PointLightsArrayCBuf>> m_constantBuffer;
     };
 }

--- a/nc/source/graphics/Model.cpp
+++ b/nc/source/graphics/Model.cpp
@@ -11,7 +11,10 @@ namespace nc::graphics
     }
 
     Model::Model(const Mesh& mesh, const Material& material)
-        : m_mesh(mesh), m_material(material)
+        : m_mesh{mesh},
+          m_material{material},
+          m_indexBuffer{nullptr},
+          m_transformConstantBuffer{nullptr}
     {
         InitializeGraphicsPipeline();
     }
@@ -20,7 +23,7 @@ namespace nc::graphics
     {
         using namespace nc::graphics::d3dresource;
         auto bufferId = std::to_string(GraphicsResourceManager::AssignId());
-        m_transformConstantBuffer = TransformConstBufferVertexPixel::AcquireUnique(bufferId, *this, 0u, 2u);
+        m_transformConstantBuffer = std::make_unique<TransformConstBufferVertexPixel>(bufferId, *this, 0u, 2u);
         m_indexBuffer = m_mesh.QueryGraphicsResource<d3dresource::IndexBuffer>();
     }
 

--- a/nc/source/graphics/Model.h
+++ b/nc/source/graphics/Model.h
@@ -49,7 +49,7 @@ namespace nc::graphics
             Mesh m_mesh;
             Material m_material;
             DirectX::XMMATRIX m_transformationMatrix;
-            const d3dresource::IndexBuffer * m_indexBuffer = nullptr;
-            std::shared_ptr<d3dresource::GraphicsResource> m_transformConstantBuffer;
+            const d3dresource::IndexBuffer* m_indexBuffer;
+            std::unique_ptr<d3dresource::TransformConstBufferVertexPixel> m_transformConstantBuffer;
     };
 }

--- a/nc/source/graphics/ResourceGroup.cpp
+++ b/nc/source/graphics/ResourceGroup.cpp
@@ -11,7 +11,7 @@ namespace nc::graphics
         }
     }
 
-    void ResourceGroup::AddGraphicsResource(std::shared_ptr<d3dresource::GraphicsResource> res)
+    void ResourceGroup::AddGraphicsResource(d3dresource::GraphicsResource* res)
     {
         m_resources.push_back(std::move(res));
     }

--- a/nc/source/graphics/ResourceGroup.cpp
+++ b/nc/source/graphics/ResourceGroup.cpp
@@ -13,6 +13,6 @@ namespace nc::graphics
 
     void ResourceGroup::AddGraphicsResource(d3dresource::GraphicsResource* res)
     {
-        m_resources.push_back(std::move(res));
+        m_resources.push_back(res);
     }
 }

--- a/nc/source/graphics/ResourceGroup.h
+++ b/nc/source/graphics/ResourceGroup.h
@@ -18,10 +18,10 @@ namespace nc::graphics
             template<std::derived_from<d3dresource::GraphicsResource> T>
             T * QueryGraphicsResource() noexcept;
             void Bind() const;
-            void AddGraphicsResource(std::shared_ptr<d3dresource::GraphicsResource> res);
+            void AddGraphicsResource(d3dresource::GraphicsResource* res);
 
         protected:
-            std::vector<std::shared_ptr<d3dresource::GraphicsResource>> m_resources;
+            std::vector<d3dresource::GraphicsResource*> m_resources;
     };
 
     template<std::derived_from<d3dresource::GraphicsResource> T>
@@ -29,7 +29,7 @@ namespace nc::graphics
     {
         for(auto& res : m_resources)
         {
-            if(auto pt = dynamic_cast<T*>(res.get()))
+            if(auto pt = dynamic_cast<T*>(res))
             {
                 return pt;
             }

--- a/nc/source/graphics/d3dresource/GraphicsResource.cpp
+++ b/nc/source/graphics/d3dresource/GraphicsResource.cpp
@@ -253,6 +253,8 @@ namespace nc::graphics::d3dresource
         GetContext()->PSSetShader(m_pixelShader.Get(),nullptr,0u);
     }
 
+    std::unique_ptr<VertexConstantBuffer<TransformConstBufferVertex::Transforms>> TransformConstBufferVertex::m_vcbuf = nullptr;
+
     TransformConstBufferVertex::TransformConstBufferVertex(const std::string& tag, Model & parent, UINT slot)
         : m_parent( parent )
     {
@@ -286,10 +288,10 @@ namespace nc::graphics::d3dresource
         };
     }
 
-    std::unique_ptr<VertexConstantBuffer<TransformConstBufferVertex::Transforms>> TransformConstBufferVertex::m_vcbuf;
+    std::unique_ptr<PixelConstantBuffer<TransformConstBufferVertex::Transforms>> TransformConstBufferVertexPixel::m_pcbuf = nullptr;
 
     TransformConstBufferVertexPixel::TransformConstBufferVertexPixel(const std::string& tag, Model & parent, UINT slotVertex, UINT slotPixel)
-    : TransformConstBufferVertex(tag, parent, slotVertex)
+        : TransformConstBufferVertex(tag, parent, slotVertex)
     {
         (void)tag;
         if(!m_pcbuf)
@@ -310,8 +312,6 @@ namespace nc::graphics::d3dresource
         m_pcbuf->Update(transforms);
         m_pcbuf->Bind();
     }
-
-    std::unique_ptr<PixelConstantBuffer<TransformConstBufferVertex::Transforms>> TransformConstBufferVertexPixel::m_pcbuf;
 
     InputLayout::InputLayout(const std::string& tag,
                              const std::vector<D3D11_INPUT_ELEMENT_DESC>& layout,

--- a/nc/source/graphics/d3dresource/GraphicsResource.h
+++ b/nc/source/graphics/d3dresource/GraphicsResource.h
@@ -83,7 +83,6 @@ namespace nc::graphics::d3dresource
             using ConstantBuffer<T>::ConstantBuffer;
             void Bind() noexcept override;
             static std::string GetUID(const T& consts, UINT slot) noexcept;
-            static std::shared_ptr<GraphicsResource> AcquireUnique(const T& consts, UINT slot);      
     };
 }
 
@@ -266,12 +265,6 @@ namespace nc::graphics::d3dresource
             void Bind() noexcept override;
             static std::string GetUID(const std::string& tag) noexcept; //, const Model& parent, UINT slot) noexcept;
 
-            //should test if these need to be unique
-            static std::shared_ptr<GraphicsResource> AcquireUnique(const std::string& tag, Model & parent, UINT slot)
-            {
-                return std::make_shared<TransformConstBufferVertex>(tag, parent, slot);
-            }
-
         protected:
             struct Transforms
             {
@@ -293,12 +286,6 @@ namespace nc::graphics::d3dresource
             TransformConstBufferVertexPixel(const std::string& tag, Model& parent, UINT slotVertex = 0u, UINT slotPixel = 2u);
             void Bind() noexcept override;
             static std::string GetUID(const std::string& tag) noexcept; //, const Model& parent, UINT slot) noexcept;
-
-            //should test if these need to be unique
-            static std::shared_ptr<GraphicsResource> AcquireUnique(const std::string& tag, Model & parent, UINT slotVertex, UINT slotPixel)
-            {
-                return std::make_shared<TransformConstBufferVertexPixel>(tag, parent, slotVertex, slotPixel);
-            }
 
         protected:
             void UpdateBindImplementation(const Transforms& transforms) noexcept;
@@ -418,12 +405,6 @@ namespace nc::graphics::d3dresource
     void PixelConstantBuffer<T>::Bind() noexcept
     {
         GetContext()->PSSetConstantBuffers(m_slot, 1u, m_constantBuffer.GetAddressOf());
-    }
-
-    template<class T>
-    std::shared_ptr<GraphicsResource> PixelConstantBuffer<T>::AcquireUnique(const T& consts, UINT slot)
-    {
-        return std::make_shared<PixelConstantBuffer<T>>(consts, slot);
     }
 
     template<class T>

--- a/nc/source/graphics/techniques/PhongShadingTechnique.cpp
+++ b/nc/source/graphics/techniques/PhongShadingTechnique.cpp
@@ -46,7 +46,8 @@ namespace nc::graphics
             single.AddGraphicsResource(GraphicsResourceManager::Acquire<d3dresource::PixelShader>(defaultShaderPath + "pbrpixelshader.cso"));
             single.AddGraphicsResource(GraphicsResourceManager::Acquire<d3dresource::Blender>(BLENDER_TAG));
             single.AddGraphicsResource(GraphicsResourceManager::Acquire<d3dresource::Sampler>(SAMPLER_TAG));
-            single.AddGraphicsResource(PixelConstantBuffer<MaterialProperties>::AcquireUnique(materialProperties, 1u));
+            m_materialPropertiesBuffer = std::make_unique<PixelConstantBuffer<MaterialProperties>>(materialProperties, 1u);
+            single.AddGraphicsResource(m_materialPropertiesBuffer.get());
         }
         AddStep(std::move(single));
     }

--- a/nc/source/graphics/techniques/PhongShadingTechnique.h
+++ b/nc/source/graphics/techniques/PhongShadingTechnique.h
@@ -9,11 +9,19 @@
 
 namespace nc::graphics
 {
+    namespace d3dresource
+    {
+        template<typename T>
+        class PixelConstantBuffer;
+    }
+
     class PhongShadingTechnique : public Technique
     {
         public:
             PhongShadingTechnique(const std::vector<std::string>& texturePaths, MaterialProperties materialProperties = {});
             static size_t GetUID(TechniqueType type, const std::vector<std::string>& texturePaths) noexcept;
 
+        private:
+            std::unique_ptr<d3dresource::PixelConstantBuffer<MaterialProperties>> m_materialPropertiesBuffer;
     };
 }


### PR DESCRIPTION
-GfxResManager creates unique_ptrs and returns non-owning * from Acquire instead of shared_ptr.
-All AcquireUnique methods removed from GraphicsResource.h and replaced with calls to make_unique. This seems simpler and clearly indicates that the caller is responsible for the resource.